### PR TITLE
Fixed bug in CryptoModule.CryptoContainerDeserializer

### DIFF
--- a/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoModule.java
+++ b/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoModule.java
@@ -95,7 +95,7 @@ public class CryptoModule extends SimpleModule {
 
 		@Override
 		public JsonDeserializer<CryptoContainer<?>> createContextual(DeserializationContext ctx, BeanProperty prop) {
-			return new  CryptoContainerDeserializer(ctx.getContextualType());
+			return new CryptoContainerDeserializer(ctx.getContextualType());
 		}
 
 	}

--- a/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoModule.java
+++ b/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoModule.java
@@ -66,17 +66,21 @@ public class CryptoModule extends SimpleModule {
 			implements
 				ContextualDeserializer {
 
-		private JavaType contextualType;
+		private JavaType boundType;
 
-		@Override
-		public CryptoContainer<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+		public CryptoContainerDeserializer() {
+		}
 
-			JavaType boundType = contextualType.getBindings().getBoundType(0);
+		private CryptoContainerDeserializer(JavaType contextualType) {
+			boundType = contextualType.getBindings().getBoundType(0);
 			if (boundType == null) {
 				throw new IllegalArgumentException(
 						"Cannot infer the container's parameter type. Avoid using RAW-types or use 'new TypeReference<CryptoContainer<String>>() {}' depending on your context.");
 			}
+		}
 
+		@Override
+		public CryptoContainer<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 			Class<?> targetType = boundType.getRawClass();
 
 			JsonNode tree = jp.getCodec().readTree(jp);
@@ -91,8 +95,7 @@ public class CryptoModule extends SimpleModule {
 
 		@Override
 		public JsonDeserializer<CryptoContainer<?>> createContextual(DeserializationContext ctx, BeanProperty prop) {
-			contextualType = ctx.getContextualType();
-			return this;
+			return new  CryptoContainerDeserializer(ctx.getContextualType());
 		}
 
 	}

--- a/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
+++ b/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
@@ -54,6 +54,16 @@ public class RoundtripTest {
 
         assertEquals(b.pair.get(), b2.pair.get());
 
+        Baz baz = new Baz();
+        baz.name = new CryptoContainer<>("Peter", id);
+        baz.pair = new CryptoContainer<>(new Pair<>("hubba", 77), id);
+        json = om.writeValueAsString(baz);
+        System.out.println(json);
+        Baz baz2 = om.readValue(json, Baz.class);
+
+        assertEquals(baz.name.get(), baz2.name.get());
+        assertEquals(baz.pair.get(), baz2.pair.get());
+
         CryptoContainer<String> c = new CryptoContainer<>("hubbi", id);
         json = om.writeValueAsString(c);
         System.out.println(json);
@@ -75,6 +85,12 @@ public class RoundtripTest {
     @Data
     public static class Bar {
         int bar = 7;
+        CryptoContainer<Pair<String, Integer>> pair;
+    }
+
+    @Data
+    public static class Baz {
+        CryptoContainer<String> name;
         CryptoContainer<Pair<String, Integer>> pair;
     }
 


### PR DESCRIPTION
When having multiple CryptoContainers inside one JSON, the type information extracted in the createContextual() method was overwritten in each successive call, because there was only one instance responsible for all CryptoContainer fields in the object. Now returning one dedicated instance per CryptoContainer field.