### PR TITLE
Fix NPE when de- and re-serializing a crypto-container

### DIFF
--- a/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoContainer.java
+++ b/cryptoshred-core/src/main/java/eu/prismacapacity/cryptoshred/core/CryptoContainer.java
@@ -132,7 +132,7 @@ public class CryptoContainer<T> extends OptionalBehavior<T> {
 	protected void encrypt(CryptoKeyRepository keyRepository, CryptoEngine engine, ObjectMapper om) {
 		CryptoKey key = keyRepository.getOrCreateKeyFor(subjectId, algo, size);
 		byte[] bytes;
-		bytes = om.writeValueAsBytes(cachedValue.get());
+		bytes = om.writeValueAsBytes(value());
 		this.encryptedBytes = engine.encrypt(bytes, algo, key);
 	}
 }

--- a/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
+++ b/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
@@ -76,6 +76,25 @@ public class RoundtripTest {
 
     }
 
+    @Test
+    void testDeAndReSerialization() throws Exception{
+        // arrange
+
+        CryptoSubjectId id = CryptoSubjectId.of(UUID.randomUUID());
+        Foo foo = new Foo();
+        foo.name = new CryptoContainer<>("Peter", id);
+        // just need a crypto-json that can be deserialized for later
+        String json = om.writeValueAsString(foo);
+
+        // act
+
+        final Foo deserializedFoo = om.readValue(json, new TypeReference<Foo>() {
+        });
+        // not accessing deserializedFoo.name here, so that the lazy decryption does not occur
+        final String reserializedFoo = om.writeValueAsString(deserializedFoo);
+        assertNotNull(reserializedFoo);
+    }
+
     @Data
     public static class Foo {
         int bar = 7;

--- a/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
+++ b/cryptoshred-core/src/test/java/eu/prismacapacity/cryptoshred/core/RoundtripTest.java
@@ -92,6 +92,9 @@ public class RoundtripTest {
         });
         // not accessing deserializedFoo.name here, so that the lazy decryption does not occur
         final String reserializedFoo = om.writeValueAsString(deserializedFoo);
+
+        // assert that it worked and we got a result and no exception
+
         assertNotNull(reserializedFoo);
     }
 


### PR DESCRIPTION
When de-serializing a JSON containing a `CryptoContainer<?>` into a Java object and then trying to re-serialize the same object back into JSON without using `CryptoContainer#get()` or other methods causing decryption of the entry (and thus population of the cache), a NPE gets thrown as the cache is not populated.

See the attached test that fails for the old version but works with the fix.

The fix simply uses `CryptoContainer#value()` internally to obtain the data to encrypt, which triggers the lazy decryption if the cache is unpopulated.